### PR TITLE
Don't add the VIP to keepalived.conf if it is already present

### DIFF
--- a/start-keepalived.sh
+++ b/start-keepalived.sh
@@ -12,8 +12,13 @@ sed -i -e "s/<--AUTHPASS-->/${AUTHPASS}/g" /etc/keepalived/keepalived.conf
 
 for VIP in $( env | grep VIP | sort | awk -F "=" '{print $2}' )
 do
-  echo "Adding VIP: ${VIP}"
-  sed -i -e "s/virtual_ipaddress {/virtual_ipaddress {\n        ${VIP}/" /etc/keepalived/keepalived.conf;
+  if grep -q $VIP /etc/keepalived/keepalived.conf;
+  then
+    echo "VIP ${VIP} already added"
+  else
+    echo "Adding VIP: ${VIP}"
+    sed -i -e "s/virtual_ipaddress {/virtual_ipaddress {\n        ${VIP}/" /etc/keepalived/keepalived.conf;
+  fi
 done
 
 echo "=> Starting Keepalived ... : "


### PR DESCRIPTION
Don't add the VIP to keepalived.conf if it is already there, in case the container gets restarted.  Otherwise the list of VIPs keeps repeating
every time the container restarts.